### PR TITLE
no typescript template

### DIFF
--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -50,7 +50,7 @@ jobs:
     - name: Step 3 - Generate Electron application
       run: |
         # Create Electron TypeScript project
-        npx create-electron-app "${{ github.event.inputs.repo_name }}" --template=typescript
+        npx create-electron-app "${{ github.event.inputs.repo_name }}"
         
         # Install additional dependencies
         cd "${{ github.event.inputs.repo_name }}"


### PR DESCRIPTION
This pull request includes a small but significant change to the `.github/workflows/create-typescript-electron-repository.yaml` file. The change involves modifying the command used to generate an Electron application by removing the `--template=typescript` option.

* [`.github/workflows/create-typescript-electron-repository.yaml`](diffhunk://#diff-575e892f06a6062c56fc4dbdfb1bfaf420b814774530148a2b4cbd7a0432969eL53-R53): Removed the `--template=typescript` option from the `npx create-electron-app` command.