### PR TITLE
create electron vite app with vanilla react and vue ts

### DIFF
--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -23,7 +23,10 @@ on:
         options:
           - electron-with-typescript
           - electron-forge-with-webpack
-        default: 'electron-with-typescript'
+          - vite-ts
+          - vite-react-ts
+          - vite-vue-ts
+        default: 'vite-ts'
       ts_target:
         description: 'TypeScript target'
         required: false
@@ -299,6 +302,41 @@ jobs:
         fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
         EOF
         
+        node update_package.js
+        rm update_package.js
+
+    - name: Step 3c - Generate Electron with Vite
+      if: ${{ startsWith(github.event.inputs.build_tool, 'vite-') }}
+      run: |
+        # Determine template based on build_tool selection
+        TEMPLATE=""
+        case "${{ github.event.inputs.build_tool }}" in
+          "vite-ts")
+            TEMPLATE="vanilla-ts"
+            ;;
+          "vite-react-ts")
+            TEMPLATE="react-ts"
+            ;;
+          "vite-vue-ts")
+            TEMPLATE="vue-ts"
+            ;;
+        esac
+        
+        # Create Electron app with selected template
+        npm create @quick-start/electron "${{ github.event.inputs.repo_name }}" -- --template $TEMPLATE
+        cd "${{ github.event.inputs.repo_name }}"
+        
+        # Update package.json with metadata
+        cat > update_package.js << 'EOF'
+        const fs = require('fs');
+        const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+        packageJson.author = {
+          name: "${{ github.event.inputs.author_name }}",
+          email: "${{ github.event.inputs.author_email }}"
+        };
+        packageJson.description = "${{ github.event.inputs.description }}";
+        fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
+        EOF
         node update_package.js
         rm update_package.js
 


### PR DESCRIPTION
This pull request introduces support for generating Electron apps using Vite in addition to the existing options. The most important changes include updating the build tool options and adding a new step to handle Vite-based templates.

### Updates to build tool options:
* [`.github/workflows/create-typescript-electron-repository.yaml`](diffhunk://#diff-575e892f06a6062c56fc4dbdfb1bfaf420b814774530148a2b4cbd7a0432969eL26-R29): Added new build tool options `vite-ts`, `vite-react-ts`, and `vite-vue-ts` and set `vite-ts` as the default.

### New job steps for Vite-based templates:
* [`.github/workflows/create-typescript-electron-repository.yaml`](diffhunk://#diff-575e892f06a6062c56fc4dbdfb1bfaf420b814774530148a2b4cbd7a0432969eR308-R342): Added a new job step to generate Electron apps with Vite, including logic to select the appropriate template based on the build tool option and update `package.json` with metadata.