### PR TITLE
skip interactive input for electron vite

### DIFF
--- a/.github/workflows/create-typescript-electron-repository.yaml
+++ b/.github/workflows/create-typescript-electron-repository.yaml
@@ -322,8 +322,17 @@ jobs:
             ;;
         esac
         
+        # Convert repo name to lowercase for compatibility with electron-vite
+        REPO_NAME_LOWER=$(echo "${{ github.event.inputs.repo_name }}" | tr '[:upper:]' '[:lower:]')
+
         # Create Electron app with selected template
-        npm create @quick-start/electron "${{ github.event.inputs.repo_name }}" -- --template $TEMPLATE
+        npm create @quick-start/electron "$REPO_NAME_LOWER" -- --template $TEMPLATE --skip
+
+        # If repo name is different than lowercase version, rename directory
+        if [ "$REPO_NAME_LOWER" != "${{ github.event.inputs.repo_name }}" ]; then
+          mv "$REPO_NAME_LOWER" "${{ github.event.inputs.repo_name }}"
+        fi
+
         cd "${{ github.event.inputs.repo_name }}"
         
         # Update package.json with metadata


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/create-typescript-electron-repository.yaml` file to ensure compatibility with `electron-vite` by converting the repository name to lowercase. 

The most important change is:

* Converted the repository name to lowercase for compatibility with `electron-vite`, and added logic to rename the directory if the original repository name is different from the lowercase version. (`.github/workflows/create-typescript-electron-repository.yaml`)