### PR TITLE
workflow to create react naive app with expo

### DIFF
--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -1,0 +1,72 @@
+name: Create React Native App Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: 'Name of the React Native app'
+        required: true
+        type: string
+      description:
+        description: 'Repository description'
+        required: false
+        default: 'A React Native app created with Expo'
+      author_name:
+        description: 'Author name'
+        required: true
+        type: string
+      author_email:
+        description: 'Author email'
+        required: true
+        type: string
+      private:
+        description: 'Private repository'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  create-react-native-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          
+      - name: Create React Native app
+        run: npx create-expo-app ${{ github.event.inputs.app_name }}
+
+      - name: Initialize git repository
+        run: |
+          cd ${{ github.event.inputs.app_name }}
+          git init
+          git add .
+          git config --global user.email "${{ github.event.inputs.author_email }}"
+          git config --global user.name "${{ github.event.inputs.author_name }}"
+          git commit -m "Initial commit: Create React Native app with Expo"
+
+      - name: Create new GitHub repository
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
+            -d '{
+                  "name": "${{ github.event.inputs.repo_name }}",
+                  "description": "${{ github.event.inputs.description }}",
+                  "private": ${{ github.event.inputs.private }}
+                }' \
+            https://api.github.com/user/repos
+
+      - name: Push to new repository
+        run: |
+          cd "${{ github.event.inputs.app_name }}"
+          git config --global user.email "${{ github.event.inputs.author_email }}"
+          git config --global user.name "${{ github.event.inputs.author_name }}"
+            git init
+            git add .
+            git commit -m "Initialize Electron project with ${{ github.event.inputs.build_tool }}"
+            git branch -M main
+            git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
+            git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
+            git push -u origin main
+          env:
+            GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the creation of a React Native app repository. The workflow allows users to specify app details, initializes the project, and pushes it to a new GitHub repository.

### New GitHub Actions Workflow:

* `.github/workflows/create-react-native-app-repository.yaml`: Introduced a workflow named "Create React Native App Repository" that:
  - Accepts inputs for app name, description, author details, and repository visibility.
  - Sets up Node.js and uses `npx create-expo-app` to generate a React Native app.
  - Initializes a Git repository, commits the app, and creates a new GitHub repository using the GitHub API.
  - Pushes the initialized app to the newly created repository.