### PR TITLE
React native build fix

### DIFF
--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -61,12 +61,12 @@ jobs:
           cd "${{ github.event.inputs.app_name }}"
           git config --global user.email "${{ github.event.inputs.author_email }}"
           git config --global user.name "${{ github.event.inputs.author_name }}"
-            git init
-            git add .
-            git commit -m "Initialize Electron project with ${{ github.event.inputs.build_tool }}"
-            git branch -M main
-            git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
-            git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
-            git push -u origin main
-          env:
-            GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          git init
+          git add .
+          git commit -m "Initialize Electron project with ${{ github.event.inputs.build_tool }}"
+          git branch -M main
+          git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
+          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
+          git push -u origin main
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -37,15 +37,6 @@ jobs:
       - name: Create React Native app
         run: npx create-expo-app ${{ github.event.inputs.app_name }}
 
-      - name: Initialize git repository
-        run: |
-          cd ${{ github.event.inputs.app_name }}
-          git init
-          git add .
-          git config --global user.email "${{ github.event.inputs.author_email }}"
-          git config --global user.name "${{ github.event.inputs.author_name }}"
-          git commit -m "Initial commit: Create React Native app with Expo"
-
       - name: Create new GitHub repository
         run: |
           curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
@@ -63,10 +54,10 @@ jobs:
           git config --global user.name "${{ github.event.inputs.author_name }}"
           git init
           git add .
-          git commit -m "Initialize Electron project with ${{ github.event.inputs.build_tool }}"
+          git commit -m "Initialize React Native app with Expo"
           git branch -M main
-          git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.repo_name }}.git
-          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.repo_name }}
+          git remote add origin git@github.com:${{ github.actor }}/${{ github.event.inputs.app_name }}.git
+          git remote set-url origin https://x-access-token:${{ env.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.actor }}/${{ github.event.inputs.app_name }}
           git push -u origin main
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           curl -X POST -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
             -d '{
-                  "name": "${{ github.event.inputs.repo_name }}",
+                  "name": "${{ github.event.inputs.app_name }}",
                   "description": "${{ github.event.inputs.description }}",
                   "private": ${{ github.event.inputs.private }}
                 }' \


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for creating a React Native app repository. The changes focus on simplifying the workflow by removing redundant steps and improving consistency in naming conventions.

### Workflow simplification:

* Removed the step to initialize a local Git repository after creating the React Native app. This eliminates redundant operations since the repository is managed directly on GitHub. (`.github/workflows/create-react-native-app-repository.yaml`, [.github/workflows/create-react-native-app-repository.yamlL40-R44](diffhunk://#diff-d80a1a7522659ce702cf5695901bc717cc6dfa73a09aa09da9a46f761eea8098L40-R44))

### Naming consistency:

* Updated the repository name in the GitHub API request to use the app name (`github.event.inputs.app_name`) instead of a separate `repo_name` input, ensuring consistency across the workflow. (`.github/workflows/create-react-native-app-repository.yaml`, [.github/workflows/create-react-native-app-repository.yamlL40-R44](diffhunk://#diff-d80a1a7522659ce702cf5695901bc717cc6dfa73a09aa09da9a46f761eea8098L40-R44))
* Adjusted the Git commit message and remote repository URL to reflect the creation of a React Native app with Expo, aligning with the app name input. (`.github/workflows/create-react-native-app-repository.yaml`, [.github/workflows/create-react-native-app-repository.yamlL66-R60](diffhunk://#diff-d80a1a7522659ce702cf5695901bc717cc6dfa73a09aa09da9a46f761eea8098L66-R60))