### PR TITLE
fix tsdx template

### DIFF
--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -40,7 +40,7 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
-          npx tsdx create "${{ github.event.inputs.repo_name }}" --template ts --yes
+          npx tsdx create "${{ github.event.inputs.repo_name }}" --template basic --y
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set description="${{ github.event.inputs.description }}"


### PR DESCRIPTION
This pull request updates the TypeScript library scaffolding process in the GitHub Actions workflow. The change modifies the template used by the `tsdx create` command.

* **Workflow update for TypeScript library scaffolding**:
  * [`.github/workflows/create-typescript-library.yaml`](diffhunk://#diff-66b550bee1fa57949b6ecccb7266a0daff7dca2f40f6729e28c384ce90936537L43-R43): Changed the `tsdx create` command to use the `basic` template instead of the `ts` template. This simplifies the scaffolding process by opting for a more general-purpose template.