### PR TITLE
presetting username and email

### DIFF
--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -40,11 +40,12 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
+          export npm_config_init_author_name="${{ github.event.inputs.author_name }}"
+          export npm_config_init_author_email="${{ github.event.inputs.author_email }}"
           npx tsdx create "${{ github.event.inputs.repo_name }}" --template basic --y
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set description="${{ github.event.inputs.description }}"
-          npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"
           npm install
       
       - name: Create new GitHub repository


### PR DESCRIPTION
This pull request updates the `.github/workflows/create-typescript-library.yaml` workflow file to improve how author information is handled during the scaffolding of a TypeScript library.

Workflow improvements:

* Updated the `Scaffold TypeScript library` step to use environment variables (`npm_config_init_author_name` and `npm_config_init_author_email`) for setting the author's name and email, instead of directly setting the `author` field in the `package.json` file. This change aligns with npm's standard configuration practices.