### PR TITLE
switch to create-ts-fast because tsdx is not well maintained

### DIFF
--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -39,12 +39,14 @@ jobs:
           node-version: '18.x'
           
       - name: Scaffold TypeScript library
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
         run: |
-          export npm_config_init_author_name="${{ github.event.inputs.author_name }}"
-          export npm_config_init_author_email="${{ github.event.inputs.author_email }}"
-          npx tsdx create "${{ github.event.inputs.repo_name }}" --template basic --y
+          npx create-ts-fast@latest "{{ github.event.inputs.package_name }}"  -- --template universal
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
+          npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"          npm pkg set license="InnoBridge"
           npm pkg set description="${{ github.event.inputs.description }}"
           npm install
       


### PR DESCRIPTION
This pull request updates the `.github/workflows/create-typescript-library.yaml` file to improve the TypeScript library scaffolding process. The changes involve switching to a new library creation tool, updating the Node.js setup, and refining package metadata configuration.

Changes to the TypeScript library scaffolding process:

* Replaced the `tsdx` library creation tool with `create-ts-fast` for generating TypeScript libraries using the `universal` template. (`[.github/workflows/create-typescript-library.yamlR42-R49](diffhunk://#diff-66b550bee1fa57949b6ecccb7266a0daff7dca2f40f6729e28c384ce90936537R42-R49)`)
* Updated the Node.js setup to use `actions/setup-node@v3` for consistency and maintainability. (`[.github/workflows/create-typescript-library.yamlR42-R49](diffhunk://#diff-66b550bee1fa57949b6ecccb7266a0daff7dca2f40f6729e28c384ce90936537R42-R49)`)
* Refined package metadata configuration by setting the `author` field with the author's name and email, and explicitly setting the license to "InnoBridge". (`[.github/workflows/create-typescript-library.yamlR42-R49](diffhunk://#diff-66b550bee1fa57949b6ecccb7266a0daff7dca2f40f6729e28c384ce90936537R42-R49)`)