### PR TITLE
minor changes

### DIFF
--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -39,14 +39,12 @@ jobs:
           node-version: '18.x'
           
       - name: Scaffold TypeScript library
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
         run: |
-          npx create-ts-fast@latest "{{ github.event.inputs.package_name }}"  -- --template universal
+          npx create-ts-fast@latest "{{ github.event.inputs.package_name }}" -- --template universal
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
-          npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"          npm pkg set license="InnoBridge"
+          npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"
+          npm pkg set license="InnoBridge"
           npm pkg set description="${{ github.event.inputs.description }}"
           npm install
       


### PR DESCRIPTION
This pull request updates the `.github/workflows/create-typescript-library.yaml` file to streamline the process of scaffolding a TypeScript library. The most notable change is the removal of the `actions/setup-node` step, as the Node.js version is already specified elsewhere.

Workflow simplification:

* Removed the `actions/setup-node@v3` step from the workflow, as the Node.js version (`18.x`) is already specified in the `node-version` configuration. This reduces redundancy in the workflow definition.