### PR TITLE
money money money $

### DIFF
--- a/.github/workflows/create-typescript-library.yaml
+++ b/.github/workflows/create-typescript-library.yaml
@@ -40,7 +40,7 @@ jobs:
           
       - name: Scaffold TypeScript library
         run: |
-          npx create-ts-fast@latest "{{ github.event.inputs.package_name }}" -- --template universal
+          npx create-ts-fast@latest "${{ github.event.inputs.package_name }}" -- --template universal
           cd "${{ github.event.inputs.repo_name }}"
           npm pkg set name="${{ github.event.inputs.package_name }}"
           npm pkg set author="${{ github.event.inputs.author_name }} <${{ github.event.inputs.author_email }}>"


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/create-typescript-library.yaml` file. The change replaces double curly braces with `${{ }}` syntax for interpolating `github.event.inputs.package_name` in the `npx` command.

* [`.github/workflows/create-typescript-library.yaml`](diffhunk://#diff-66b550bee1fa57949b6ecccb7266a0daff7dca2f40f6729e28c384ce90936537L43-R43): Updated the syntax for variable interpolation in the `Scaffold TypeScript library` step to use `${{ }}` for consistency and correctness.