### PR TITLE
gitignore eas.json

### DIFF
--- a/.github/workflows/create-react-native-app-repository.yaml
+++ b/.github/workflows/create-react-native-app-repository.yaml
@@ -53,6 +53,7 @@ jobs:
           git config --global user.email "${{ github.event.inputs.author_email }}"
           git config --global user.name "${{ github.event.inputs.author_name }}"
           git init
+          echo 'eas.json' >> .gitignore
           git add .
           git commit -m "Initialize React Native app with Expo"
           git branch -M main


### PR DESCRIPTION
This pull request introduces a minor update to the workflow for initializing a React Native app repository. The change ensures that the `eas.json` file is ignored by Git when the repository is created.

* Added `eas.json` to `.gitignore` during repository initialization to prevent it from being tracked by Git.